### PR TITLE
Hide email for hire me pages other than mobile

### DIFF
--- a/css/styles-v2-non-retina.css
+++ b/css/styles-v2-non-retina.css
@@ -254,8 +254,8 @@
     	padding-bottom: 8px;
 	}
 
-	.contacts-row {
-		visibility: hidden;
+	.contacts-container, .contact-email-container {
+		display: none;
 	}
 
 	/*.contact-icon-img {

--- a/css/styles-v2.css
+++ b/css/styles-v2.css
@@ -269,7 +269,7 @@
     	padding-bottom: 24px;
 	}
 
-	.contacts-row {
-		visibility: hidden;
+	.contacts-container, .contact-email-container {
+		display: none;
 	}
 }


### PR DESCRIPTION
change to display none from visibility hidden as visibility hidden still takes up the space on the page. It's just that the elements are hidden from plain sight. But this would lead to incorrect sizing of the page if the properties for "hidden" elements are not defined properly.